### PR TITLE
Method execution: Inject property instead of adding.

### DIFF
--- a/src/Collection/Kmap.php
+++ b/src/Collection/Kmap.php
@@ -66,6 +66,9 @@ class Kmap implements CollectionInterface {
 		return $this->array[ $offset ];
 	}
 
+	/**
+	 * @throws Exception
+	 */
 	#[Override]
 	public function offsetSet( mixed $offset, mixed $value ): void {
 		if ( ! $this->mutable ) {
@@ -77,6 +80,9 @@ class Kmap implements CollectionInterface {
 		$this->keys             = array_keys( $this->array );
 	}
 
+	/**
+	 * @throws Exception
+	 */
 	#[Override]
 	public function offsetUnset( mixed $offset ): void {
 		if ( ! $this->mutable ) {

--- a/tests/Axpecto/MethodExecution/Builder/MethodExecutionBuildHandlerTest.php
+++ b/tests/Axpecto/MethodExecution/Builder/MethodExecutionBuildHandlerTest.php
@@ -42,7 +42,7 @@ class MethodExecutionBuildHandlerTest extends TestCase {
 
 		// Expect the method and property to be added to the context
 		$this->buildContextMock->expects( $this->once() )->method( 'addMethod' )->with( $method, $signature, $implementation );
-		$this->buildContextMock->expects( $this->once() )->method( 'addProperty' )->with( MethodExecutionProxy::class, $this->anything() );
+		$this->buildContextMock->expects( $this->once() )->method( 'injectProperty' )->with( 'proxy', MethodExecutionProxy::class );
 
 		// Execute the intercept method
 		$this->methodExecutionBuildHandler->intercept( $this->annotationMock, $this->buildContextMock );
@@ -64,7 +64,7 @@ class MethodExecutionBuildHandlerTest extends TestCase {
 
 		// Expect the method and property to be added to the context
 		$this->buildContextMock->expects( $this->once() )->method( 'addMethod' )->with( $method, $signature, $implementation );
-		$this->buildContextMock->expects( $this->once() )->method( 'addProperty' )->with( MethodExecutionProxy::class, $this->anything() );
+		$this->buildContextMock->expects( $this->once() )->method( 'injectProperty' )->with( 'proxy', MethodExecutionProxy::class );
 
 		// Execute the intercept method
 		$this->methodExecutionBuildHandler->intercept( $this->annotationMock, $this->buildContextMock );


### PR DESCRIPTION
We now use the injectProperty method from the BuildContext instead of manually adding the injected property to the context